### PR TITLE
Game-like (complex): bug fixes and small cleanups

### DIFF
--- a/public/assets/demos/gamelike/blob47.manim
+++ b/public/assets/demos/gamelike/blob47.manim
@@ -57,18 +57,18 @@ version: 1.0
     text(exo2_14, "Tile:", #aaaaaa): 200, 38
     placeholder(generated(cross(30, 26, white)), builderParameter("grassBtn")) {
         pos: 240, 32
-        settings{color=>#AA8844, width:int=>30, height:int=>26}
+        settings{color=>#44AA44, width:int=>30, height:int=>26}
     }
     placeholder(generated(cross(30, 26, white)), builderParameter("dirtBtn")) {
         pos: 280, 32
-        settings{color=>#44AA44, width:int=>30, height:int=>26}
+        settings{color=>#AA8844, width:int=>30, height:int=>26}
     }
 
     // Status
     #statusText(updatable) text(exo2_14, "Draw on the map!", #aaaaaa, left, 400): 400, 38
 
     // Dirt background
-    bitmap(generated(color(640, 448, #66AA44))): 0, 70
+    bitmap(generated(color(640, 448, #8b6f47))): 0, 70
 
     // Map container - autotile TileGroup goes here
     #mapContainer(updatable) point: 0, 70

--- a/src/screens/gamelike/Blob47DemoScreen.hx
+++ b/src/screens/gamelike/Blob47DemoScreen.hx
@@ -116,9 +116,12 @@ class Blob47DemoScreen extends DemoScreenBase {
 	}
 
 	function clearMap():Void {
+		// Fill with the OPPOSITE of paintValue so the user can immediately
+		// paint with their currently-selected tile on a clean background.
+		final fillValue = 1 - paintValue;
 		for (y in 0...GRID_H) {
 			for (x in 0...GRID_W) {
-				grid[y][x] = paintValue;
+				grid[y][x] = fillValue;
 			}
 		}
 		rebuildAutotile();
@@ -147,8 +150,6 @@ class Blob47DemoScreen extends DemoScreenBase {
 					randomize();
 				else if (source == clearButton) {
 					clearMap();
-					paintValue = 1 - paintValue;
-					updateTileSelection();
 				}
 				else if (source == grassButton) {
 					paintValue = 1;

--- a/src/screens/gamelike/GridDemoScreen.hx
+++ b/src/screens/gamelike/GridDemoScreen.hx
@@ -630,10 +630,8 @@ class GridDemoScreen extends DemoScreenBase {
 				toRemove.push({col: col, row: row});
 		});
 		for (c in toRemove) {
-			if (hexGrid.isOccupied(c.col, c.row)) {
+			if (hexGrid.isOccupied(c.col, c.row))
 				hexGrid.clear(c.col, c.row);
-				hexGrid.setCellParameter(c.col, c.row, "occupied", false);
-			}
 			// removeCell auto-refreshes card targets
 			hexGrid.removeCell(c.col, c.row);
 		}


### PR DESCRIPTION
## Summary
- **Blob47**: Fixed confusing Clear button behavior. Previously it filled the grid with the current paint value AND silently swapped the selected tile. Now Clear fills with the opposite of the selected tile so the user can immediately paint with their selection on a clean background, and `paintValue` stays stable.
- **Blob47 .manim**: Swapped grass/dirt button colors so they match their labels (grass = green `#44AA44`, dirt = brown `#AA8844`). Changed the map backdrop from green to brown so it reads as dirt beneath the grass autotiles.
- **GridDemoScreen**: Removed a dead `setCellParameter("occupied", false)` call that ran immediately before `removeCell` on the same hex cell during ring removal.

## Test plan
- [x] `npm run build` (Haxe) compiles cleanly
- [x] `npm run react:build` succeeds
- [x] Blob47 screen loads — green grass button, brown dirt button, brown dirt backdrop. Clear now wipes the map to the non-selected tile without changing the active selection.
- [x] Cards screen (Card States tab) loads without errors.
- [x] Grid screen loads — rect + hex + grid-to-grid sections all render.
- [x] Skill Tree (Equipment Tree) loads with icons in upgradable state.
- [x] Project List loads and shows detail panel + log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)