### PR TITLE
UI screens: bug fixes and DSL improvements

### DIFF
--- a/public/assets/demos/ui/sliders.manim
+++ b/public/assets/demos/ui/sliders.manim
@@ -12,18 +12,18 @@ version: 1.0
 
     // Small slider (100)
     text(exo2_light_14, "Small (100px)", #cccccc): 0, 35
-    placeholder(generated(cross(310, 20, #FF0000)), builderParameter("slider1")) {
+    placeholder(generated(cross(110, 20, #FF0000)), builderParameter("slider1")) {
         pos: 0, 55
-        settings{size:int=>300}
+        settings{size:int=>100}
     }
     ninepatch("ui", "Window_3x3_idle", 120, 30): 330, 48
     #value1(updatable) text(exo2_14, "0", #ffffff, center, 100): 340, 55
 
     // Medium slider (200)
     text(exo2_light_14, "Medium (200px)", #cccccc): 0, 100
-    placeholder(generated(cross(310, 20, #FF0000)), builderParameter("slider2")) {
+    placeholder(generated(cross(210, 20, #FF0000)), builderParameter("slider2")) {
         pos: 0, 120
-        settings{size:int=>300}
+        settings{size:int=>200}
     }
     ninepatch("ui", "Window_3x3_idle", 120, 30): 330, 113
     #value2(updatable) text(exo2_14, "0", #ffffff, center, 100): 340, 120

--- a/react_src/PlaygroundBridge.ts
+++ b/react_src/PlaygroundBridge.ts
@@ -24,7 +24,7 @@ export const CATEGORIES: CategoryInfo[] = [
             { name: 'sliders', displayName: 'Sliders', category: 'UI Components', manimFile: 'demos/ui/sliders.manim' },
             { name: 'dropdowns', displayName: 'Dropdowns', category: 'UI Components', manimFile: 'demos/ui/dropdowns.manim' },
             { name: 'scrollableList', displayName: 'Scrollable List', category: 'UI Components', manimFile: 'demos/ui/scrollable-list.manim' },
-            { name: 'radio', displayName: 'Radio Buttons', category: 'UI Components', manimFile: 'demos/ui/radio.manim' },
+            { name: 'radio', displayName: 'Radio Buttons', category: 'UI Components', manimFile: 'demos/ui/radios-demo.manim' },
             { name: 'progressBar', displayName: 'Progress Bars', category: 'UI Components', manimFile: 'demos/ui/progress-bar.manim' },
             { name: 'draggable', displayName: 'Draggable', category: 'UI Components', manimFile: 'demos/ui/draggable.manim' },
             { name: 'dialogs', displayName: 'Dialogs', category: 'UI Components', manimFile: 'demos/ui/dialogs.manim' },

--- a/src/screens/ui/CheckboxesDemoScreen.hx
+++ b/src/screens/ui/CheckboxesDemoScreen.hx
@@ -18,7 +18,7 @@ class CheckboxesDemoScreen extends DemoScreenBase {
 	var disableToggle:Null<UIStandardMultiCheckbox>;
 
 	override public function load():Void {
-		setupDemo("Checkboxes", "Checkbox, tickbox, toggle, radio, and simple variants with selection tracking");
+		setupDemo("Checkboxes", "Checkbox, tickbox, toggle, radio, radio2, and simple variants with selection tracking and disabled state");
 
 		demoBuilder = screenManager.buildFromResourceName("demos/ui/checkboxes-demo.manim", false);
 		checkboxBuilder = screenManager.buildFromResourceName("checkbox.manim", false);

--- a/src/screens/ui/DropdownsDemoScreen.hx
+++ b/src/screens/ui/DropdownsDemoScreen.hx
@@ -5,8 +5,6 @@ import bh.ui.*;
 import bh.ui.UIMultiAnimDropdown.UIStandardMultiAnimDropdown;
 import bh.ui.UIMultiAnimCheckbox.UIStandardMultiCheckbox;
 import bh.multianim.MultiAnimBuilder;
-import bh.ui.screens.UIScreen;
-import bh.ui.screens.ScreenManager;
 import bh.base.MacroUtils;
 
 class DropdownsDemoScreen extends DemoScreenBase {
@@ -82,9 +80,10 @@ class DropdownsDemoScreen extends DemoScreenBase {
 		dropdownDisabled = ui.dropdownDisabled;
 		dropdownDisabled.disabled = true;
 		disableCheckbox = ui.disableCheckbox;
+		// dropdownDisabled stays permanently disabled — excluded from the toggle list
 		allDropdowns = [
 			dropdownScrollable, dropdownAutoFew, dropdownAutoMany,
-			dropdownCustom, dropdownWide, dropdownLarge, dropdownDisabled,
+			dropdownCustom, dropdownWide, dropdownLarge,
 		];
 
 		addBuilderResult(demoResult);


### PR DESCRIPTION
## Summary

Audit of src/screens/ui/* and public/assets/demos/ui/*.manim. Bugs fixed in 4 files (8 insertions, 9 deletions).

### Screens touched

- **SlidersDemoScreen** (sliders.manim): Small/Medium/Large sliders all rendered at size=300 even though their labels said 100/200/300 px. Fixed the .manim settings and placeholder bounds so each slider matches its label.
- **DropdownsDemoScreen**: the seventh dropdown is initialized as permanently disabled. The global disable-toggle was overwriting dropdownDisabled.disabled = pressed on every change, which re-enabled it whenever the user toggled the checkbox off. Removed it from allDropdowns so it stays disabled. Also removed two unused imports flagged by the IDE.
- **CheckboxesDemoScreen**: setupDemo description didn't mention the radio2 style or the Disabled-State section the .manim actually renders. Updated the text to match.
- **PlaygroundBridge.ts**: the source-viewer entry for "Radio Buttons" pointed to the legacy demos/ui/radio.manim, but the screen actually loads demos/ui/radios-demo.manim. Fixed so the viewer shows the file the screen is using.

### Screens reviewed, no change needed

ButtonsDemoScreen, ScrollableListDemoScreen, RadioDemoScreen, ProgressBarDemoScreen, DraggableDemoScreen (already covers 4 scenarios — drop zones, constraint, priority zones, drag layer), DialogsDemoScreen, TabsDemoScreen, TextInputDemoScreen, TooltipsPanelsDemoScreen.

All these use the safe \`final updatable = ...; if (updatable != null) ...\` pattern — no chained-null-deref hazards found in this scope.

## Test plan

- [x] npm run build (Haxe) passes
- [x] npm run react:build (tsc + Vite) passes
- [x] Manual smoke via vite --port 3320 + Playwright navigate to #screen=sliders, #screen=dropdowns, #screen=radio - no console errors beyond a favicon 404
- [ ] Visual review of slider sizes on the playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)