### PR TITLE
Graphics screens: bug fixes and DSL improvements

### DIFF
--- a/public/assets/demos/graphics/bitmaps-atlas.manim
+++ b/public/assets/demos/graphics/bitmaps-atlas.manim
@@ -136,4 +136,63 @@ version: 1.0
   text(m6x11, "2x", #888888): 30, 960
   text(m6x11, "3x", #888888): 80, 960
   text(m6x11, "4x", #888888): 150, 960
+
+  // ====== Right column: filter showcases ======
+
+  // Section 9: @tint annotation - recolor a white sprite
+  text(exo2_16, "@tint(color) - recolor white bitmaps:", #cccccc): 600, 0
+
+  @tint(#ff4444) bitmap(generated(color(40, 40, #ffffff))): 600, 30
+  @tint(#44ff44) bitmap(generated(color(40, 40, #ffffff))): 650, 30
+  @tint(#4488ff) bitmap(generated(color(40, 40, #ffffff))): 700, 30
+  @tint(#ffcc44) bitmap(generated(color(40, 40, #ffffff))): 750, 30
+  @tint(#ff44ff) bitmap(generated(color(40, 40, #ffffff))): 800, 30
+
+  text(m6x11, "red",     #888888, center, 40): 600, 76
+  text(m6x11, "green",   #888888, center, 40): 650, 76
+  text(m6x11, "blue",    #888888, center, 40): 700, 76
+  text(m6x11, "gold",    #888888, center, 40): 750, 76
+  text(m6x11, "magenta", #888888, center, 40): 800, 76
+
+  // Section 10: filter: replaceColor - palette swap
+  text(exo2_16, "filter: replaceColor([from], [to]):", #cccccc): 600, 110
+
+  bitmap(generated(colorWithText(60, 60, #ff0000, "RED", white, m6x11))): 600, 140
+  bitmap(generated(colorWithText(60, 60, #ff0000, "GRN", white, m6x11))) {
+    filter: replaceColor([#ff0000], [#00cc44])
+    pos: 670, 140
+  }
+  bitmap(generated(colorWithText(60, 60, #ff0000, "BLU", white, m6x11))) {
+    filter: replaceColor([#ff0000], [#3366cc])
+    pos: 740, 140
+  }
+  bitmap(generated(colorWithText(60, 60, #ff0000, "PUR", white, m6x11))) {
+    filter: replaceColor([#ff0000], [#9933cc])
+    pos: 810, 140
+  }
+
+  // Section 11: filter: outline / group / grayscale
+  text(exo2_16, "filter: outline / group / grayscale:", #cccccc): 600, 220
+
+  bitmap(generated(color(50, 50, #4488ff))) {
+    filter: outline(2, #ffff00)
+    pos: 600, 250
+  }
+  bitmap(generated(color(50, 50, #4488ff))) {
+    filter: outline(4, #ff0000)
+    pos: 670, 250
+  }
+  bitmap(generated(color(50, 50, #4488ff))) {
+    filter: group(outline(2, #000000), brightness(1.4))
+    pos: 740, 250
+  }
+  bitmap(generated(color(50, 50, #4488ff))) {
+    filter: grayscale(1.0)
+    pos: 810, 250
+  }
+
+  text(m6x11, "ol 2px",     #888888, center, 50): 600, 310
+  text(m6x11, "ol 4px",     #888888, center, 50): 670, 310
+  text(m6x11, "ol+bright",  #888888, center, 50): 740, 310
+  text(m6x11, "grayscale",  #888888, center, 50): 810, 310
 }

--- a/public/assets/demos/graphics/ninepatch.manim
+++ b/public/assets/demos/graphics/ninepatch.manim
@@ -68,6 +68,7 @@ paths {
 }
 
 #resizablePanel programmable(width:60..510=210, height:60..210=150) {
+    text(m6x11, "Drag corner to resize:", #cccccc): 0, -20
     ninepatch("ui", "Window_3x3_idle", $width, $height): 0, 0
     #sizeText(updatable) text(m6x11, "210 x 150", #ffffff, left, 200): 10, 10
 }

--- a/public/assets/demos/graphics/pixels-graphics.manim
+++ b/public/assets/demos/graphics/pixels-graphics.manim
@@ -4,18 +4,18 @@ version: 1.0
   // Section 1: Pixels primitives
   text(exo2_16, "Pixels primitives:", #cccccc): 0, 0
 
-  // Colored squares
+  // Colored squares (filledrect)
   point {
     pos: 0, 30
     pixels (
-      rect 0, 0, 20, 20, #ff4444
-      rect 20, 0, 20, 20, #44ff44
-      rect 0, 20, 20, 20, #4444ff
-      rect 20, 20, 20, 20, #ffff44
+      filledrect 0, 0, 20, 20, #ff4444
+      filledrect 20, 0, 20, 20, #44ff44
+      filledrect 0, 20, 20, 20, #4444ff
+      filledrect 20, 20, 20, 20, #ffff44
     ) {
       scale: 3
     }
-    text(m6x11, "Colored squares", #888888): 0, 130
+    text(m6x11, "filledrect", #888888): 0, 130
   }
 
   // Diagonal lines
@@ -50,18 +50,17 @@ version: 1.0
     text(m6x11, "Individual pixels", #888888): 0, 130
   }
 
-  // Border rectangle
+  // Outline rectangle (rect = unfilled)
   point {
     pos: 500, 30
     pixels (
-      rect 0, 0, 1, 30, #ff7f50
-      rect 0, 0, 30, 1, #ff7f50
-      rect 29, 0, 1, 30, #ff7f50
-      rect 0, 29, 30, 1, #ff7f50
+      rect 0, 0, 30, 30, #ff7f50
+      rect 4, 4, 22, 22, #44aaff
+      rect 9, 9, 12, 12, #ffff44
     ) {
       scale: 4
     }
-    text(m6x11, "1px border rect", #888888): 0, 130
+    text(m6x11, "rect (outline)", #888888): 0, 130
   }
 
   // Section 2: Graphics primitives
@@ -124,6 +123,14 @@ version: 1.0
       );
     );
     text(m6x11, "Triangle", #888888): -26, 40
+  }
+
+  // Ellipse + Arc (standalone shapes)
+  point {
+    pos: 760, 250
+    ellipse(#44cc88, filled, 80, 40): -40, -20
+    arc(#cc4488, 4, 30, 0, 270): 0, 0
+    text(m6x11, "Ellipse + Arc", #888888, center, 100): -50, 40
   }
 
   // Section 3: Combined shapes

--- a/src/screens/graphics/BitmapsAtlasDemoScreen.hx
+++ b/src/screens/graphics/BitmapsAtlasDemoScreen.hx
@@ -8,7 +8,8 @@ class BitmapsAtlasDemoScreen extends DemoScreenBase {
 	var demoBuilder:Null<MultiAnimBuilder>;
 
 	override public function load():Void {
-		setupDemo("Bitmaps & Atlas", "Generated bitmaps (color, cross, colorWithText), file bitmaps, and atlas sheet sprites");
+		setupDemo("Bitmaps & Atlas",
+			"Generated/file/sheet bitmaps; @alpha/@scale/@tint annotations; filter: replaceColor/outline/group/grayscale");
 
 		demoBuilder = screenManager.buildFromResourceName("demos/graphics/bitmaps-atlas.manim", false);
 

--- a/src/screens/graphics/NinepatchDemoScreen.hx
+++ b/src/screens/graphics/NinepatchDemoScreen.hx
@@ -4,7 +4,6 @@ import bh.ui.*;
 import bh.ui.UIMultiAnimDraggable;
 import bh.ui.UIMultiAnimDraggable.DropZoneId;
 import bh.multianim.MultiAnimBuilder;
-import bh.base.FontManager;
 import h2d.col.Point;
 import h2d.col.Bounds;
 
@@ -29,13 +28,7 @@ class NinepatchDemoScreen extends DemoScreenBase {
 		result.object.setPosition(40, 80);
 		addBuilderResult(result);
 
-		// Resizable ninepatch panel
-		var label = new h2d.Text(FontManager.getFontByName("m6x11"));
-		label.text = "Drag corner to resize:";
-		label.textColor = 0xFFCCCCCC;
-		label.setPosition(PANEL_X, PANEL_Y - 20);
-		addObjectToLayer(label, DefaultLayer);
-
+		// Resizable ninepatch panel (label included in #resizablePanel)
 		panelResult = demoBuilder.buildWithParameters("resizablePanel", ["width" => panelWidth, "height" => panelHeight], null, null, true);
 		panelResult.object.setPosition(PANEL_X, PANEL_Y);
 		addBuilderResult(panelResult);

--- a/src/screens/graphics/PixelsGraphicsDemoScreen.hx
+++ b/src/screens/graphics/PixelsGraphicsDemoScreen.hx
@@ -8,7 +8,8 @@ class PixelsGraphicsDemoScreen extends DemoScreenBase {
 	var demoBuilder:Null<MultiAnimBuilder>;
 
 	override public function load():Void {
-		setupDemo("Pixels & Graphics", "Drawing primitives with pixels{} and graphics{} elements");
+		setupDemo("Pixels & Graphics",
+			"pixels (pixel, line, rect, filledrect) and graphics (rect, circle, ellipse, arc, roundRect, line, polygon)");
 
 		demoBuilder = screenManager.buildFromResourceName("demos/graphics/pixels-graphics.manim", false);
 

--- a/src/screens/graphics/RichTextDemoScreen.hx
+++ b/src/screens/graphics/RichTextDemoScreen.hx
@@ -36,6 +36,7 @@ class RichTextDemoScreen extends DemoScreenBase {
 	}
 
 	function showPopup(msg:String):Void {
+		if (result == null) return;
 		if (popupText != null) {
 			popupText.remove();
 		}


### PR DESCRIPTION
## Summary

Bug fixes and DSL feature coverage for the 6 graphics demo screens.

**Bug fixes**
- pixels-graphics.manim Section 1 "Colored squares" was using rect (outline) for what should be solid squares - switched to filledrect. The cell now matches its label.
- pixels-graphics.manim "1px border rect" cell was hand-rolling 4 thin filled rects; replaced with a single outline rect (with two nested boxes).
- RichTextDemoScreen.showPopup added null-guard on result.

**DSL coverage improvements**
- bitmaps-atlas.manim adds a right-column filter showcase:
  - Section 9: @tint(color) recoloring 5 white bitmaps.
  - Section 10: filter: replaceColor([from], [to]) swapping red to green/blue/purple (replaceColor was 0 uses across the playground).
  - Section 11: filter: outline(...), filter: group(outline, brightness), filter: grayscale(...).
- pixels-graphics.manim adds an Ellipse + Arc cell using standalone shape syntax.
- ninepatch.manim "Drag corner to resize:" label moved into the #resizablePanel programmable (was previously a raw h2d.Text in Haxe).
- setupDemo() descriptions updated for Bitmaps & Atlas and Pixels & Graphics.

**Out of scope**
- RichTextDemoScreen already exercises 16 rich-text sections - no DSL changes needed.
- RichTextAutofitDemoScreen requires direct ProgrammableBuilder.autoFitFirstFit/Fill calls; left as-is.
- NinepatchDemoScreen still has a raw h2d.Tile.fromColor drag handle - small enough not worth a programmable.

## Test plan

- [x] npm run build (Haxe to JS)
- [x] npm run react:build (TypeScript + Vite)
- [x] Playwright smoke: bitmapsAtlas, ninepatch, textFonts, richText, richTextAutofit, pixelsGraphics - no console errors (other than missing favicon), all sections render.

Generated with Claude Code
