### PR TITLE
Advanced screens: bug fixes and DSL improvements

### DIFF
--- a/public/assets/demos/advanced/conditionals.manim
+++ b/public/assets/demos/advanced/conditionals.manim
@@ -3,7 +3,9 @@ version: 1.0
 // Conditionals Demo
 // All conditional types demonstrated
 
-#conditionalsDemo programmable(value:0..100=50) {
+#conditionalsDemo programmable(value:0..100=50, tier:[low, mid, high]=mid) {
+    pos: 50, 140
+
     text(exo2_16, "Conditional Types", #7fdbda, left, 400): 0, 0
     text(exo2_light_14, "Drag the slider to see which conditional blocks match the current value.", #aaaaaa, left, 700): 0, 30
 
@@ -31,14 +33,34 @@ version: 1.0
     @else(value <= 70) text(m6x11, "  @else(value <= 70): MID", #ffaa44, left, 300): 0, 260
     @default text(m6x11, "  @default: HIGH", #44ff44, left, 300): 0, 260
 
-    // Section 5: Visual indicator bar
-    text(m6x11, "5. Visual bar (width = $value * 4):", #cccccc, left, 400): 0, 300
-    bitmap(generated(color(400, 20, #222233))): 0, 320
-    bitmap(generated(color($value * 4, 20, #4488cc))): 0, 320
+    // Section 5: @switch — picks one arm by enum param (tier auto-derived from value)
+    text(m6x11, "5. @switch(tier):", #cccccc, left, 400): 0, 300
+    @switch(tier) {
+        low {
+            bitmap(generated(color(120, 18, #aa3333))): 0, 320
+            text(m6x11, "  tier=low (value <= 33)", #ffffff, left, 300): 130, 322
+        }
+        mid {
+            bitmap(generated(color(120, 18, #aa8833))): 0, 320
+            text(m6x11, "  tier=mid (34..66)", #ffffff, left, 300): 130, 322
+        }
+        high {
+            bitmap(generated(color(120, 18, #33aa33))): 0, 320
+            text(m6x11, "  tier=high (value >= 67)", #ffffff, left, 300): 130, 322
+        }
+    }
+
+    // Section 6: Visual indicator bar
+    text(m6x11, "6. Visual bar (width = $value * 4):", #cccccc, left, 400): 0, 360
+    bitmap(generated(color(400, 20, #222233))): 0, 380
+    bitmap(generated(color($value * 4, 20, #4488cc))): 0, 380
 
     // Current value display
-    text(exo2_20, 'Current value: ${value}', #ffffff, left, 300): 0, 370
+    #valueText(updatable) text(exo2_20, 'Current value: ${value}  |  tier: $tier', #ffffff, left, 400): 0, 420
 
-    // Slider label
-    text(exo2_14, "Value slider", #888888, left, 200): 0, 420
+    // Slider (placeholder filled by screen code)
+    placeholder(generated(cross(310, 20, #FF0000)), builderParameter("valueSlider")) {
+        pos: 0, 470
+        settings{size:int=>300}
+    }
 }

--- a/public/assets/demos/advanced/incremental.manim
+++ b/public/assets/demos/advanced/incremental.manim
@@ -4,6 +4,8 @@ version: 1.0
 // Build once, update live via setParameter() without rebuild
 
 #incrementalDemo programmable(value:0..100=50) {
+    pos: 50, 140
+
     text(exo2_16, "Incremental Mode", #7fdbda, left, 400): 0, 0
     text(exo2_light_14, "The elements below update live when the slider changes value.", #aaaaaa, left, 600): 0, 30
 
@@ -32,6 +34,12 @@ version: 1.0
         bitmap(generated(color(20, 20, #446688))): 0, 350
     }
 
-    // Slider label
-    text(exo2_14, "Drag slider to update all elements live", #888888, left, 400): 0, 400
+    // Hint text — uses string interpolation; updates automatically with $value
+    text(m6x11, 'Drag slider to update all elements. Current value: ${value}', #888888, left, 500): 0, 405
+
+    // Slider placeholder — filled in by screen code
+    placeholder(generated(cross(310, 20, #FF0000)), builderParameter("valueSlider")) {
+        pos: 0, 430
+        settings{size:int=>300}
+    }
 }

--- a/src/screens/advanced/ConditionalsDemoScreen.hx
+++ b/src/screens/advanced/ConditionalsDemoScreen.hx
@@ -4,61 +4,48 @@ import bh.ui.UIElement;
 import bh.ui.*;
 import bh.ui.UIMultiAnimSlider.UIStandardMultiAnimSlider;
 import bh.multianim.MultiAnimBuilder;
-import bh.ui.screens.UIScreen;
-import bh.ui.screens.ScreenManager;
-import bh.base.FontManager;
+import bh.base.MacroUtils;
 
 class ConditionalsDemoScreen extends DemoScreenBase {
 	var demoBuilder:Null<MultiAnimBuilder>;
-	var conditionalResult:Null<BuilderResult>;
+	var demoResult:Null<BuilderResult>;
 	var valueSlider:Null<UIStandardMultiAnimSlider>;
-	var currentValue:Int = 50;
-	var statusText:Null<h2d.Text>;
 
 	override public function load():Void {
-		setupDemo("Conditionals", "All conditional types: @(), @if(), @else, @default, range, comparison operators");
+		setupDemo("Conditionals", "All conditional types: @(), @if(), @else, @default, @switch, range, comparison operators");
 
 		demoBuilder = screenManager.buildFromResourceName("demos/advanced/conditionals.manim", false);
 
-		// Build with incremental mode for live updates
-		conditionalResult = demoBuilder.buildWithParameters("conditionalsDemo", ["value" => 50], null, null, true);
-		conditionalResult.object.setPosition(50, 140);
-		addBuilderResult(conditionalResult);
+		var ui = MacroUtils.macroBuildWithParameters(demoBuilder, "conditionalsDemo", ["value" => 50, "tier" => "mid"], [
+			valueSlider => addSlider(stdBuilder, 50),
+		], true);
 
-		// Value slider
-		valueSlider = addSlider(stdBuilder, null, 50);
-		addElement(valueSlider, DefaultLayer);
-		valueSlider.getObject().setPosition(50, 640);
-
-		// Status text
-		statusText = new h2d.Text(FontManager.getFontByName("exo2_light_14"));
-		statusText.text = 'Value: $currentValue | Drag slider to change which conditionals match';
-		statusText.textColor = 0xFFCCCCCC;
-		statusText.setPosition(50, 610);
-		addObjectToLayer(statusText, DefaultLayer);
+		demoResult = ui.builderResults;
+		valueSlider = ui.valueSlider;
+		addBuilderResult(demoResult);
 	}
 
 	override public function onScreenEvent(event:UIScreenEvent, source:Null<UIElement>):Void {
 		switch event {
 			case UIChangeValue(val):
-				if (source == valueSlider) {
-					currentValue = val;
-					if (conditionalResult != null) {
-						conditionalResult.setParameter("value", val);
-					}
-					if (statusText != null) {
-						statusText.text = 'Value: $currentValue';
-					}
+				if (source == valueSlider && demoResult != null) {
+					demoResult.setParameter("value", val);
+					demoResult.setParameter("tier", tierFor(val));
 				}
 			default:
 		}
 	}
 
+	static function tierFor(value:Int):String {
+		if (value <= 33) return "low";
+		if (value <= 66) return "mid";
+		return "high";
+	}
+
 	override public function onClear():Void {
 		super.onClear();
 		demoBuilder = null;
-		conditionalResult = null;
+		demoResult = null;
 		valueSlider = null;
-		statusText = null;
 	}
 }

--- a/src/screens/advanced/IncrementalDemoScreen.hx
+++ b/src/screens/advanced/IncrementalDemoScreen.hx
@@ -4,51 +4,32 @@ import bh.ui.UIElement;
 import bh.ui.*;
 import bh.ui.UIMultiAnimSlider.UIStandardMultiAnimSlider;
 import bh.multianim.MultiAnimBuilder;
-import bh.ui.screens.UIScreen;
-import bh.ui.screens.ScreenManager;
-import bh.base.FontManager;
+import bh.base.MacroUtils;
 
 class IncrementalDemoScreen extends DemoScreenBase {
 	var demoBuilder:Null<MultiAnimBuilder>;
-	var incrementalResult:Null<BuilderResult>;
+	var demoResult:Null<BuilderResult>;
 	var valueSlider:Null<UIStandardMultiAnimSlider>;
-	var currentValue:Int = 50;
-	var statusText:Null<h2d.Text>;
 
 	override public function load():Void {
 		setupDemo("Incremental Updates", "Build once, update live via setParameter() without full rebuild");
 
 		demoBuilder = screenManager.buildFromResourceName("demos/advanced/incremental.manim", false);
 
-		// Build demo with incremental mode enabled
-		incrementalResult = demoBuilder.buildWithParameters("incrementalDemo", ["value" => 50], null, null, true);
-		incrementalResult.object.setPosition(50, 140);
-		addBuilderResult(incrementalResult);
+		var ui = MacroUtils.macroBuildWithParameters(demoBuilder, "incrementalDemo", ["value" => 50], [
+			valueSlider => addSlider(stdBuilder, 50),
+		], true);
 
-		// Value slider
-		valueSlider = addSlider(stdBuilder, null, 50);
-		addElement(valueSlider, DefaultLayer);
-		valueSlider.getObject().setPosition(50, 620);
-
-		// Status text
-		statusText = new h2d.Text(FontManager.getFontByName("exo2_light_14"));
-		statusText.text = 'Value: $currentValue | Drag slider to update live';
-		statusText.textColor = 0xFFCCCCCC;
-		statusText.setPosition(50, 590);
-		addObjectToLayer(statusText, DefaultLayer);
+		demoResult = ui.builderResults;
+		valueSlider = ui.valueSlider;
+		addBuilderResult(demoResult);
 	}
 
 	override public function onScreenEvent(event:UIScreenEvent, source:Null<UIElement>):Void {
 		switch event {
 			case UIChangeValue(val):
-				if (source == valueSlider) {
-					currentValue = val;
-					if (incrementalResult != null) {
-						incrementalResult.setParameter("value", val);
-					}
-					if (statusText != null) {
-						statusText.text = 'Value: $currentValue';
-					}
+				if (source == valueSlider && demoResult != null) {
+					demoResult.setParameter("value", val);
 				}
 			default:
 		}
@@ -57,8 +38,7 @@ class IncrementalDemoScreen extends DemoScreenBase {
 	override public function onClear():Void {
 		super.onClear();
 		demoBuilder = null;
-		incrementalResult = null;
+		demoResult = null;
 		valueSlider = null;
-		statusText = null;
 	}
 }

--- a/src/screens/advanced/InteractivesDemoScreen.hx
+++ b/src/screens/advanced/InteractivesDemoScreen.hx
@@ -5,8 +5,6 @@ import bh.ui.*;
 import bh.ui.UIRichInteractiveHelper;
 import bh.multianim.MultiAnimBuilder;
 import bh.multianim.MultiAnimBuilder.BuilderResolvedSettings;
-import bh.ui.screens.UIScreen;
-import bh.ui.screens.ScreenManager;
 
 class InteractivesDemoScreen extends DemoScreenBase {
 	var demoBuilder:Null<MultiAnimBuilder>;

--- a/src/screens/advanced/LoadoutRuntimeDemoScreen.hx
+++ b/src/screens/advanced/LoadoutRuntimeDemoScreen.hx
@@ -43,6 +43,7 @@ class LoadoutRuntimeDemoScreen extends LoadoutLabDemoBase {
 	}
 
 	override function setUpdatableText(name:String, text:String):Void {
+		if (demoResult == null || !demoResult.hasName(name)) return;
 		final u = demoResult.getUpdatable(name);
 		if (u != null) u.updateText(text);
 	}


### PR DESCRIPTION
Audit of src/screens/advanced/* (excluding SettingsDemoScreen). Bug fixes plus modest .manim DSL over raw Haxe. Conditionals demo: adds @switch(tier) section, drops the hand-rolled h2d.Text label, moves slider into a placeholder; tier derived from value (low<=33, mid<=66, high>=67). Incremental demo: drops the hand-rolled h2d.Text, slider becomes a placeholder, value display uses string-interpolation. LoadoutRuntime.setUpdatableText now guards getUpdatable() with hasName() (parity with the 1D/2D helpers, which already had it). InteractivesDemoScreen drops unused UIScreen/ScreenManager imports. Verified: npm run build, npm run react:build, playwright load for featureShowcase, incremental, conditionals, expressions, interactives, macroPerformance, loadoutRuntime, loadoutCodegen, only console errors are unrelated favicon.ico 404s.